### PR TITLE
Handle `TaggingService`s persisted without `key_field`/`value_field` properties

### DIFF
--- a/src/localstack_persist/hooks.py
+++ b/src/localstack_persist/hooks.py
@@ -1,6 +1,7 @@
 import logging
 
 from localstack.runtime import hooks
+from localstack.utils.tagging import TaggingService
 from moto.core.common_models import CloudFormationModel
 
 from .state import STATE_TRACKER
@@ -12,6 +13,9 @@ LOG = logging.getLogger(__name__)
 def on_infra_start():
     # HACK for "global" models that were persisted without a `partition` field
     setattr(CloudFormationModel, "partition", "aws")
+    # HACK for TaggingServices that were persisted without the `key_field`/`value_field` properties
+    setattr(TaggingService, "key_field", "Key")
+    setattr(TaggingService, "value_field", "Value")
 
     STATE_TRACKER.load_all_services_state()
     STATE_TRACKER.start()

--- a/src/localstack_persist/prepare_service.py
+++ b/src/localstack_persist/prepare_service.py
@@ -17,7 +17,6 @@ def prepare_service(service_name: str):
 
 @once
 def prepare_s3():
-
     from .s3.storage import PersistedS3ObjectStore
     from localstack.services.s3.models import S3Object
 
@@ -32,7 +31,7 @@ def prepare_s3():
 
         migrate_ephemeral_object_store(old_objects_path, store)
 
-    # HACK for CertBundles that were persisted without the `internal_last_modified`/`sse_key_hash`/`precondition` properties
+    # HACK for S3Objects that were persisted without the `internal_last_modified`/`sse_key_hash`/`precondition` properties
     setattr(S3Object, "internal_last_modified", None)
     setattr(S3Object, "sse_key_hash", None)
     setattr(S3Object, "precondition", None)


### PR DESCRIPTION
These properties were only added in v4.3.0, so state persisted from earlier versions will not have them.

Fixes #25 